### PR TITLE
docs: update min go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ guidance how to install this take a look at our [documentation][docs].
 
 Make sure you have a working Go environment, for further reference or a guide
 take a look at the [install instructions][golang]. This project requires
-Go >= v1.18, at least that's the version we are using.
+Go >= v1.23.1, at least that's the version we are using.
 
 ```console
 git clone https://github.com/kleister/kleister-api.git


### PR DESCRIPTION
When trying to build the API with go v1.23.0, there is an error thrown about min required version not being met. Seems like the version in the docs is incorrect then.

```sh
(re)installing /***/go/bin/oapi-codegen-v2.4.1
go: oapi-codegen.mod requires go >= 1.23.1 (running go 1.23.0)
make: *** [/***/go/bin/oapi-codegen-v2.4.1] Error 1
```
